### PR TITLE
Allow truncation of error messages

### DIFF
--- a/ma_error.c
+++ b/ma_error.c
@@ -196,6 +196,7 @@ SQLRETURN MADB_SetNativeError(MADB_Error *Error, SQLSMALLINT HandleType, void *P
   if (Errormsg)
   {
     strncpy(Error->SqlErrorMsg + Error->PrefixLen, Errormsg, SQL_MAX_MESSAGE_LENGTH - Error->PrefixLen);
+    Error->SqlErrorMsg[SQL_MAX_MESSAGE_LENGTH] = '\0';
   }
   if (Sqlstate)
     strcpy_s(Error->SqlState, SQLSTATE_LENGTH + 1, Sqlstate);
@@ -225,12 +226,13 @@ SQLRETURN MADB_SetError(MADB_Error  *Error,
 
   if (NativeErrorMsg)
   {
-    strcpy_s(Error->SqlErrorMsg + Error->PrefixLen, SQL_MAX_MESSAGE_LENGTH + 1 - Error->PrefixLen, NativeErrorMsg);
+    strncpy(Error->SqlErrorMsg + Error->PrefixLen, NativeErrorMsg, SQL_MAX_MESSAGE_LENGTH - Error->PrefixLen);
+    Error->SqlErrorMsg[SQL_MAX_MESSAGE_LENGTH] = '\0';
   }
   else
   {
-    strcpy_s(Error->SqlErrorMsg + Error->PrefixLen, SQL_MAX_MESSAGE_LENGTH + 1 - Error->PrefixLen,
-             MADB_ErrorList[ErrorCode].SqlErrorMsg);
+    strncpy(Error->SqlErrorMsg + Error->PrefixLen, MADB_ErrorList[ErrorCode].SqlErrorMsg, SQL_MAX_MESSAGE_LENGTH - Error->PrefixLen);
+    Error->SqlErrorMsg[SQL_MAX_MESSAGE_LENGTH] = '\0';
   }
   strcpy_s(Error->SqlState, SQLSTATE_LENGTH + 1, MADB_ErrorList[ErrorCode].SqlState);
   Error->NativeError= NativeError;


### PR DESCRIPTION
When `strcpy_s` (https://en.cppreference.com/w/c/string/byte/strcpy) is used, truncation is prohibited. However, when we set the error message for a statement, it's much better to have it truncated to 512 characters than empty. 