### PR TITLE
Fix rewrite CALL into ECHO

### DIFF
--- a/ma_parse.c
+++ b/ma_parse.c
@@ -494,7 +494,7 @@ int ParseQuery(MADB_QUERY *Query, my_bool replaceCall)
 
       if (replaceCall &&
         StmtTokensCount == 0 &&
-        _strnicmp(Query, "CALL", 4))
+        _strnicmp(p, "CALL", 4) == 0)
       {
         memcpy(p, "ECHO", 4);
       }


### PR DESCRIPTION
we compared Query to CALL, but Query is a struct, not text.