### PR TITLE
Check for mysql error in FetchRowCsps

### DIFF
--- a/ma_statement.c
+++ b/ma_statement.c
@@ -3078,6 +3078,7 @@ MYSQL_ROW FetchRowCsps(MADB_Stmt* Stmt, unsigned long **field_lengths)
     {
       Stmt->stmt->state= MYSQL_STMT_USER_FETCHING;
     }
+
     if (mysql_errno(Stmt->stmt->mysql))
     {
       MADB_SetError(&Stmt->Error, MADB_ERR_HY000, mysql_error(Stmt->stmt->mysql),


### PR DESCRIPTION
Similarly to PR #22, the error packet may be sent after the column definition packet. In Client Side Prepared Statement mode with NO_CACHE=1, this means that the query execution would succeed, and a resource error like OOM would be seen when the client tries to read the rows.

Steps to reproduce the bug:
1. Create a table: `CREATE ROWSTORE TABLE t_big (id BIGINT AUTO_INCREMENT PRIMARY KEY, text_col TEXT);`.
2. Insert initial data: `INSERT INTO t_big (text_col) VALUES ("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");`.
3. Run the following insert query until server responds with a OOM error (with 16 GB of memory on server, this would happen when the table row count reaches 16M rows) `INSERT INTO t_big (text_col) SELECT text_col FROM t_big;`.
4. Run the following insert query until the server responds with a OOM error (around 20 times): `INSERT INTO t_big (text_col) SELECT text_col FROM t_big LIMIT 100000;`
5. The following query can be used to reproduce the issue: `SELECT t1.id, COUNT(t2.id) FROM t_big t1 JOIN t_big t2 ON t1.text_col = t2.text_col GROUP BY t1.id;`. Before this PR, the driver would return a resultset with 2 columns and 0 rows, and no error.