### PR TITLE
Changed KILL to KILL CONNECTION using node_id

### DIFF
--- a/test/catalog1.c
+++ b/test/catalog1.c
@@ -1046,19 +1046,10 @@ ODBC_TEST(t_bug26934)
   SQLHENV    Env1;
   SQLHDBC    Connection1;
   SQLHSTMT   Stmt1;
-  SQLINTEGER ConnectionId;
-  char       Kill[64];
 
   ODBC_Connect(&Env1, &Connection1, &Stmt1);
 
-  OK_SIMPLE_STMT(Stmt1, "SELECT connection_id()");
-  CHECK_STMT_RC(Stmt1, SQLFetch(Stmt1));
-  ConnectionId= my_fetch_int(Stmt1, 1);
-  CHECK_STMT_RC(Stmt1, SQLFreeStmt(Stmt1, SQL_CLOSE));
-
-  /* From another connection, kill the connection created above */
-  sprintf(Kill, "KILL %d", ConnectionId);
-  OK_SIMPLE_STMT(Stmt, Kill);
+  killConnection(Stmt1, Stmt);
   
   EXPECT_STMT(Stmt1, SQLTables(Stmt1, (SQLCHAR *)"%", 1, NULL, SQL_NTS,
                                 NULL, SQL_NTS, NULL, SQL_NTS), SQL_ERROR);

--- a/test/error.c
+++ b/test/error.c
@@ -228,14 +228,7 @@ ODBC_TEST(t_bug3456)
 
   /* Create a new connection that we deliberately will kill */
   ODBC_Connect(&henv2, &Connection2, &Stmt2);
-  OK_SIMPLE_STMT(Stmt2, "SELECT connection_id()");
-  CHECK_STMT_RC(Stmt2, SQLFetch(Stmt2));
-  connection_id= my_fetch_int(Stmt2, 1);
-  CHECK_STMT_RC(Stmt2, SQLFreeStmt(Stmt2, SQL_CLOSE));
-
-  /* From another connection, kill the connection created above */
-  sprintf(buf, "KILL %d", connection_id);
-  CHECK_STMT_RC(Stmt, SQLExecDirect(Stmt, (SQLCHAR *)buf, SQL_NTS));
+  killConnection(Stmt2, Stmt);
 
   /* Now check that the connection killed returns the right SQLSTATE */
   EXPECT_STMT(Stmt2, SQLExecDirect(Stmt2, (SQLCHAR*)"SELECT connection_id()", SQL_NTS), SQL_ERROR);

--- a/test/info.c
+++ b/test/info.c
@@ -159,10 +159,6 @@ ODBC_TEST(t_bug14639)
 
   /* Create a new connection that we deliberately will kill */
   ODBC_Connect(&henv2, &Connection2, &Stmt2);
-  OK_SIMPLE_STMT(Stmt2, "SELECT connection_id()");
-  CHECK_STMT_RC(Stmt2, SQLFetch(Stmt2));
-  connection_id= my_fetch_int(Stmt2, 1);
-  CHECK_STMT_RC(Stmt2, SQLFreeStmt(Stmt2, SQL_CLOSE));
 
   /* Check that connection is alive */
   CHECK_DBC_RC(Connection2, SQLGetConnectAttr(Connection2, SQL_ATTR_CONNECTION_DEAD, &is_dead,
@@ -170,8 +166,7 @@ ODBC_TEST(t_bug14639)
   is_num(is_dead, SQL_CD_FALSE);
 
   /* From another connection, kill the connection created above */
-  sprintf(buf, "KILL %d", connection_id);
-  CHECK_STMT_RC(Stmt, SQLExecDirect(Stmt, (SQLCHAR *)buf, SQL_NTS));
+  killConnection(Stmt2, Stmt);
 
   /* Now check that the connection killed returns the right state */
   CHECK_DBC_RC(Connection, SQLGetConnectAttr(Connection2, SQL_ATTR_CONNECTION_DEAD, &is_dead,

--- a/test/tap.h
+++ b/test/tap.h
@@ -977,15 +977,10 @@ void killConnection(SQLHSTMT *Stmt1, SQLHSTMT *Stmt2 ) {
   SQLINTEGER connection_id, node_id;
   char       Kill[64], buf_get_node_id[128];
 
-  OK_SIMPLE_STMT(Stmt1, "SELECT connection_id()");
+  OK_SIMPLE_STMT(Stmt1, "SELECT connection_id(), aggregator_id();");
   CHECK_STMT_RC(Stmt1, SQLFetch(Stmt1));
   connection_id= my_fetch_int(Stmt1, 1);
-  CHECK_STMT_RC(Stmt1, SQLFreeStmt(Stmt1, SQL_CLOSE));
-
-  sprintf(buf_get_node_id, "SELECT node_id FROM INFORMATION_SCHEMA.MV_PROCESSLIST where id = %d", connection_id);
-  OK_SIMPLE_STMT(Stmt1, buf_get_node_id);
-  CHECK_STMT_RC(Stmt1, SQLFetch(Stmt1));
-  node_id = my_fetch_int(Stmt1, 1);
+  node_id = my_fetch_int(Stmt1, 2);
   CHECK_STMT_RC(Stmt1, SQLFreeStmt(Stmt1, SQL_CLOSE));
 
   /* From another connection, kill the connection created above */


### PR DESCRIPTION
- Changes for https://memsql.atlassian.net/browse/PLAT-7359. 
- Few tests were failing because KILL command wasn't specifying the Node ID of the aggregator node to which connection was made
- Fixed all tests where "KILL <connectionID>" command was being used and changed them to use "KILL CONNECTION <connectionID> <nodeId>"