### PR TITLE
fix: reset stale affected-row count when reusing a client-side prepared statement

### DIFF
--- a/ma_statement.c
+++ b/ma_statement.c
@@ -1940,6 +1940,18 @@ SQLRETURN MADB_StmtExecute(MADB_Stmt *Stmt, BOOL ExecDirect)
       LOCK_MARIADB(Stmt->Connection);
       Stmt->AffectedRows = 0;
 
+      /* Client-side prepared statements (CSPS) accumulate affected rows into
+         the underlying MYSQL_STMT's upsert_status via '+=' (see
+         CspsRunStatementQuery), and that field is never reset per execute.
+         mysql_stmt_affected_rows() reads it, so a re-executed statement whose
+         new run affects 0 rows would otherwise report the previous execute's
+         count. Reset it here at execute start so the count reflects only this
+         execution. */
+      if (Stmt->stmt)
+      {
+          Stmt->stmt->upsert_status.affected_rows = 0;
+      }
+
       if (Stmt->Ipd->Header.RowsProcessedPtr)
       {
           *Stmt->Ipd->Header.RowsProcessedPtr= 0;

--- a/test/sql_row_count.c
+++ b/test/sql_row_count.c
@@ -192,6 +192,39 @@ ODBC_TEST(t_sqlrowcnt_delete) {
     return OK;
 }
 
+// Regression test: a prepared statement that is executed more than once on the
+// same handle must report the affected-row count of the current execution only.
+// In the client-side prepared statement path the count was accumulated into the
+// underlying MYSQL_STMT and never reset per execute, so a re-execute matching 0
+// rows used to report the previous execute's non-zero count.
+ODBC_TEST(t_sqlrowcnt_reused_prepared_stmt) {
+    SQLLEN     rc;
+    SQLINTEGER grp;
+
+    OK_SIMPLE_STMT(Stmt, "DROP TABLE IF EXISTS test_rowcount_values");
+    OK_SIMPLE_STMT(Stmt, "CREATE TABLE test_rowcount_values (id INT PRIMARY KEY, grp INT)");
+    OK_SIMPLE_STMT(Stmt, "INSERT INTO test_rowcount_values VALUES (1,1),(2,1),(3,1),(4,2)");
+
+    CHECK_STMT_RC(Stmt, SQLPrepare(Stmt,
+        (SQLCHAR *)"UPDATE test_rowcount_values SET id = id + 10 WHERE grp = ?", SQL_NTS));
+    CHECK_STMT_RC(Stmt, SQLBindParameter(Stmt, 1, SQL_PARAM_INPUT, SQL_C_LONG,
+        SQL_INTEGER, 0, 0, &grp, 0, NULL));
+
+    // First execute matches 3 rows.
+    grp = 1;
+    CHECK_STMT_RC(Stmt, SQLExecute(Stmt));
+    CHECK_STMT_RC(Stmt, SQLRowCount(Stmt, &rc));
+    FAIL_IF_NE_INT(rc, 3, "first execute should report 3 affected rows");
+
+    // Re-execute the SAME handle matching 0 rows: must report 0, not the stale 3.
+    grp = 9;
+    CHECK_STMT_RC(Stmt, SQLExecute(Stmt));
+    CHECK_STMT_RC(Stmt, SQLRowCount(Stmt, &rc));
+    FAIL_IF_NE_INT(rc, 0, "re-execute matching 0 rows must report 0, not the previous count");
+
+    return OK;
+}
+
 ODBC_TEST(t_sqlrowcnt_bulk_operation) {
     SQLLEN rc;
     SQLINTEGER ids[INSERT_CNT] = {1, 2, 3};
@@ -284,6 +317,7 @@ MA_ODBC_TESTS my_tests[] =
 #endif
     {t_sqlrowcnt_insert_no_client_found_rows, "t_sqlrowcnt_insert_no_client_found_rows", NORMAL, ALL_DRIVERS},
     {t_sqlrowcnt_delete, "t_sqlrowcnt_delete", NORMAL, ALL_DRIVERS},
+    {t_sqlrowcnt_reused_prepared_stmt, "t_sqlrowcnt_reused_prepared_stmt", NORMAL, ALL_DRIVERS},
     {t_sqlrowcnt_bulk_operation, "t_sqlrowcnt_bulk_operation", NORMAL, ALL_DRIVERS},
     {t_sqlrowcnt_batch, "t_sqlrowcnt_batch", NORMAL, ALL_DRIVERS},
     {NULL, NULL, NORMAL, ALL_DRIVERS}

--- a/test/sql_row_count.c
+++ b/test/sql_row_count.c
@@ -202,11 +202,12 @@ ODBC_TEST(t_sqlrowcnt_reused_prepared_stmt) {
     SQLINTEGER grp;
 
     OK_SIMPLE_STMT(Stmt, "DROP TABLE IF EXISTS test_rowcount_values");
-    OK_SIMPLE_STMT(Stmt, "CREATE TABLE test_rowcount_values (id INT PRIMARY KEY, grp INT)");
-    OK_SIMPLE_STMT(Stmt, "INSERT INTO test_rowcount_values VALUES (1,1),(2,1),(3,1),(4,2)");
+    // 'id' is the shard key, which SingleStore forbids updating, so the UPDATE below targets 'val'.
+    OK_SIMPLE_STMT(Stmt, "CREATE TABLE test_rowcount_values (id INT PRIMARY KEY, grp INT, val INT)");
+    OK_SIMPLE_STMT(Stmt, "INSERT INTO test_rowcount_values VALUES (1,1,0),(2,1,0),(3,1,0),(4,2,0)");
 
     CHECK_STMT_RC(Stmt, SQLPrepare(Stmt,
-        (SQLCHAR *)"UPDATE test_rowcount_values SET id = id + 10 WHERE grp = ?", SQL_NTS));
+        (SQLCHAR *)"UPDATE test_rowcount_values SET val = val + 1 WHERE grp = ?", SQL_NTS));
     CHECK_STMT_RC(Stmt, SQLBindParameter(Stmt, 1, SQL_PARAM_INPUT, SQL_C_LONG,
         SQL_INTEGER, 0, 0, &grp, 0, NULL));
 


### PR DESCRIPTION
### Problem
With server-side prepared statements disabled (`NO_SSPS=1`), re-executing a **reused** prepared statement that affects **0 rows** returns the affected-row count from the *previous* execution via `SQLRowCount()`, instead of `0`. Applications that rely on `SQLRowCount()` to detect whether a DML statement matched a row (e.g. CDC/replication conflict detection) are misled by the stale count.

### Root cause
In the client-side prepared statement path, `CspsRunStatementQuery()` accumulates the count:

```c
Stmt->stmt->upsert_status.affected_rows += mysql_affected_rows(Stmt->stmt->mysql);
```

and `mysql_stmt_affected_rows()` returns that field. It is never reset at the start of `MADB_StmtExecute()`, so on a reused handle the previous execute's total carries over.

### Fix
Reset `upsert_status.affected_rows` to `0` at the top of the `MADB_SSPS_DISABLED` branch of `MADB_StmtExecute()`, alongside the existing `Stmt->AffectedRows = 0`.

### Impact
Scoped to the client-side prepared statement execute path; it only clears an accumulator immediately before that accumulator is repopulated by the current execution, so a single execute's reported count is unchanged — it only removes leftover state from a prior execute on the same handle. No effect on the server-side-prepare path.

### Testing
Adds `t_sqlrowcnt_reused_prepared_stmt` to `test/sql_row_count.c`: prepares an `UPDATE` once and executes it twice on the same handle (first matches 3 rows, then 0), asserting `SQLRowCount` returns `3` then `0`. The test runs in both server-side and client-side prepared statement modes; without the fix it fails in the client-side (`NO_SSPS`) run, which returns the stale `3`.
